### PR TITLE
fix: type confusion of NativeFunc pointers

### DIFF
--- a/asm/macros/event.inc
+++ b/asm/macros/event.inc
@@ -2348,11 +2348,10 @@
 	.endm
 
 	.macro getdifficulty var:req
-	callnative ScrCmd_getdifficulty
-	.2byte \var
+	callnative Script_GetDifficulty
 	.endm
 
 	.macro setdifficulty difficulty:req
-	callnative ScrCmd_setdifficulty
+	callnative Script_SetDifficulty
 	.byte \difficulty
 	.endm

--- a/include/difficulty.h
+++ b/include/difficulty.h
@@ -2,12 +2,16 @@
 #define GUARD_DIFFICULTY_H
 
 #include "constants/difficulty.h"
+#include "script.h"
 
 u32 GetCurrentDifficultyLevel(void);
+void SetCurrentDifficulty(u32);
+
 u32 GetBattlePartnerDifficultyLevel(u16);
 u32 GetTrainerDifficultyLevel(u16);
-void Script_IncreaseDifficulty(void);
-void Script_DecreaseDifficulty(void);
-void Script_SetDifficulty(u32);
+void Script_IncreaseDifficulty(struct ScriptContext *);
+void Script_DecreaseDifficulty(struct ScriptContext *);
+void Script_GetDifficulty(struct ScriptContext *);
+void Script_SetDifficulty(struct ScriptContext *);
 
 #endif // GUARD_DIFFICULTY_H

--- a/include/difficulty.h
+++ b/include/difficulty.h
@@ -5,7 +5,7 @@
 #include "script.h"
 
 u32 GetCurrentDifficultyLevel(void);
-void SetCurrentDifficulty(u32);
+void SetCurrentDifficultyLevel(u32);
 
 u32 GetBattlePartnerDifficultyLevel(u16);
 u32 GetTrainerDifficultyLevel(u16);

--- a/src/data/battle_partners.h
+++ b/src/data/battle_partners.h
@@ -41,20 +41,20 @@
         .party = (const struct TrainerMon[])
         {
             {
-#line 16
+#line 15
             .species = SPECIES_METANG,
             .gender = TRAINER_MON_RANDOM_GENDER,
-#line 20
-            .ev = TRAINER_PARTY_EVS(0, 252, 252, 0, 6, 0),
 #line 19
-            .iv = TRAINER_PARTY_IVS(31, 31, 31, 31, 31, 31),
+            .ev = TRAINER_PARTY_EVS(0, 252, 252, 0, 6, 0),
 #line 18
-            .lvl = 42,
+            .iv = TRAINER_PARTY_IVS(31, 31, 31, 31, 31, 31),
 #line 17
+            .lvl = 42,
+#line 16
             .nature = NATURE_BRAVE,
             .dynamaxLevel = MAX_DYNAMAX_LEVEL,
             .moves = {
-#line 21
+#line 20
                 MOVE_LIGHT_SCREEN,
                 MOVE_PSYCHIC,
                 MOVE_REFLECT,
@@ -62,20 +62,20 @@
             },
             },
             {
-#line 26
+#line 25
             .species = SPECIES_SKARMORY,
             .gender = TRAINER_MON_RANDOM_GENDER,
-#line 30
-            .ev = TRAINER_PARTY_EVS(252, 0, 0, 0, 6, 252),
 #line 29
-            .iv = TRAINER_PARTY_IVS(31, 31, 31, 31, 31, 31),
+            .ev = TRAINER_PARTY_EVS(252, 0, 0, 0, 6, 252),
 #line 28
-            .lvl = 43,
+            .iv = TRAINER_PARTY_IVS(31, 31, 31, 31, 31, 31),
 #line 27
+            .lvl = 43,
+#line 26
             .nature = NATURE_IMPISH,
             .dynamaxLevel = MAX_DYNAMAX_LEVEL,
             .moves = {
-#line 31
+#line 30
                 MOVE_TOXIC,
                 MOVE_AERIAL_ACE,
                 MOVE_PROTECT,
@@ -83,20 +83,20 @@
             },
             },
             {
-#line 36
+#line 35
             .species = SPECIES_AGGRON,
             .gender = TRAINER_MON_RANDOM_GENDER,
-#line 40
-            .ev = TRAINER_PARTY_EVS(0, 252, 0, 0, 252, 6),
 #line 39
-            .iv = TRAINER_PARTY_IVS(31, 31, 31, 31, 31, 31),
+            .ev = TRAINER_PARTY_EVS(0, 252, 0, 0, 252, 6),
 #line 38
-            .lvl = 44,
+            .iv = TRAINER_PARTY_IVS(31, 31, 31, 31, 31, 31),
 #line 37
+            .lvl = 44,
+#line 36
             .nature = NATURE_ADAMANT,
             .dynamaxLevel = MAX_DYNAMAX_LEVEL,
             .moves = {
-#line 41
+#line 40
                 MOVE_THUNDER,
                 MOVE_PROTECT,
                 MOVE_SOLAR_BEAM,

--- a/src/difficulty.c
+++ b/src/difficulty.c
@@ -1,6 +1,7 @@
 #include "global.h"
 #include "data.h"
 #include "event_data.h"
+#include "script.h"
 #include "constants/battle.h"
 
 u32 GetCurrentDifficultyLevel(void)
@@ -9,6 +10,17 @@ u32 GetCurrentDifficultyLevel(void)
         return DIFFICULTY_NORMAL;
 
     return VarGet(B_VAR_DIFFICULTY);
+}
+
+void SetCurrentDifficulty(u32 desiredDifficulty)
+{
+    if (!B_VAR_DIFFICULTY)
+        return;
+
+    if (desiredDifficulty > DIFFICULTY_MAX)
+        desiredDifficulty = DIFFICULTY_MAX;
+
+    VarSet(B_VAR_DIFFICULTY,desiredDifficulty);
 }
 
 u32 GetBattlePartnerDifficultyLevel(u16 partnerId)
@@ -40,7 +52,7 @@ u32 GetTrainerDifficultyLevel(u16 trainerId)
     return difficulty;
 }
 
-void Script_IncreaseDifficulty(void)
+void Script_IncreaseDifficulty(struct ScriptContext *ctx)
 {
     u32 currentDifficulty;
 
@@ -52,10 +64,10 @@ void Script_IncreaseDifficulty(void)
     if (currentDifficulty++ > DIFFICULTY_MAX)
         return;
 
-    Script_SetDifficulty(currentDifficulty);
+    SetCurrentDifficulty(currentDifficulty);
 }
 
-void Script_DecreaseDifficulty(void)
+void Script_DecreaseDifficulty(struct ScriptContext *ctx)
 {
     u32 currentDifficulty;
 
@@ -67,16 +79,17 @@ void Script_DecreaseDifficulty(void)
     if (!currentDifficulty)
         return;
 
-    Script_SetDifficulty(--currentDifficulty);
+    SetCurrentDifficulty(--currentDifficulty);
 }
 
-void Script_SetDifficulty(u32 desiredDifficulty)
+void Script_GetDifficulty(struct ScriptContext *ctx)
 {
-    if (!B_VAR_DIFFICULTY)
-        return;
+    gSpecialVar_Result = GetCurrentDifficultyLevel();
+}
 
-    if (desiredDifficulty > DIFFICULTY_MAX)
-        desiredDifficulty = DIFFICULTY_MAX;
+void Script_SetDifficulty(struct ScriptContext *ctx)
+{
+    u32 desiredDifficulty = ScriptReadByte(ctx);
 
-    VarSet(B_VAR_DIFFICULTY,desiredDifficulty);
+    SetCurrentDifficulty(desiredDifficulty);
 }

--- a/src/difficulty.c
+++ b/src/difficulty.c
@@ -12,7 +12,7 @@ u32 GetCurrentDifficultyLevel(void)
     return VarGet(B_VAR_DIFFICULTY);
 }
 
-void SetCurrentDifficulty(u32 desiredDifficulty)
+void SetCurrentDifficultyLevel(u32 desiredDifficulty)
 {
     if (!B_VAR_DIFFICULTY)
         return;
@@ -64,7 +64,7 @@ void Script_IncreaseDifficulty(struct ScriptContext *ctx)
     if (currentDifficulty++ > DIFFICULTY_MAX)
         return;
 
-    SetCurrentDifficulty(currentDifficulty);
+    SetCurrentDifficultyLevel(currentDifficulty);
 }
 
 void Script_DecreaseDifficulty(struct ScriptContext *ctx)
@@ -79,7 +79,7 @@ void Script_DecreaseDifficulty(struct ScriptContext *ctx)
     if (!currentDifficulty)
         return;
 
-    SetCurrentDifficulty(--currentDifficulty);
+    SetCurrentDifficultyLevel(--currentDifficulty);
 }
 
 void Script_GetDifficulty(struct ScriptContext *ctx)
@@ -91,5 +91,5 @@ void Script_SetDifficulty(struct ScriptContext *ctx)
 {
     u32 desiredDifficulty = ScriptReadByte(ctx);
 
-    SetCurrentDifficulty(desiredDifficulty);
+    SetCurrentDifficultyLevel(desiredDifficulty);
 }

--- a/src/difficulty.c
+++ b/src/difficulty.c
@@ -20,7 +20,7 @@ void SetCurrentDifficulty(u32 desiredDifficulty)
     if (desiredDifficulty > DIFFICULTY_MAX)
         desiredDifficulty = DIFFICULTY_MAX;
 
-    VarSet(B_VAR_DIFFICULTY,desiredDifficulty);
+    VarSet(B_VAR_DIFFICULTY, desiredDifficulty);
 }
 
 u32 GetBattlePartnerDifficultyLevel(u16 partnerId)

--- a/src/new_game.c
+++ b/src/new_game.c
@@ -206,7 +206,7 @@ void NewGameInitData(void)
     WipeTrainerNameRecords();
     ResetTrainerHillResults();
     ResetContestLinkResults();
-    SetCurrentDifficulty(DIFFICULTY_NORMAL);
+    SetCurrentDifficultyLevel(DIFFICULTY_NORMAL);
     ResetItemFlags();
 }
 

--- a/src/new_game.c
+++ b/src/new_game.c
@@ -206,7 +206,7 @@ void NewGameInitData(void)
     WipeTrainerNameRecords();
     ResetTrainerHillResults();
     ResetContestLinkResults();
-    Script_SetDifficulty(DIFFICULTY_NORMAL);
+    SetCurrentDifficulty(DIFFICULTY_NORMAL);
     ResetItemFlags();
 }
 

--- a/src/scrcmd.c
+++ b/src/scrcmd.c
@@ -2478,19 +2478,3 @@ void ScriptSetDoubleBattleFlag(struct ScriptContext *ctx)
 {
     sIsScriptedWildDouble = TRUE;
 }
-
-bool8 ScrCmd_getdifficulty(struct ScriptContext *ctx)
-{
-    u16 *var = GetVarPointer(ScriptReadHalfword(ctx));
-
-    *var = GetCurrentDifficultyLevel();
-    return FALSE;
-}
-
-bool8 ScrCmd_setdifficulty(struct ScriptContext *ctx)
-{
-    u8 desiredDifficulty = ScriptReadByte(ctx);
-
-    Script_SetDifficulty(desiredDifficulty);
-    return FALSE;
-}


### PR DESCRIPTION
* Resolved type confusion in `NativeFunc` function ptrs (at least as far as this PR is concerned)
* Unified `GetDifficulty` API to return result in `VAR_RESULT` like other commands do.
* Moved Native Script Functions to common file and fixed naming convention.
